### PR TITLE
msm8916-common: Enable rounded corners on windows

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -122,8 +122,8 @@
     <!-- Should the pinner service pin the Home application? -->
     <bool name="config_pinnerHomeApp">true</bool>
 
-    <!-- Disable rounded corners on windows to improve graphics performance -->
-    <bool name="config_supportsRoundedCornersOnWindows">false</bool>
+    <!-- Enable rounded corners on windows -->
+    <bool name="config_supportsRoundedCornersOnWindows">true</bool>
 
     <!-- The list of components which should be automatically disabled for a specific device. -->
     <string-array name="config_deviceDisabledComponents" translatable="false">


### PR DESCRIPTION
I've enabled rounded corners on windows for 2 purposes;
/ It just looks better on app launch transition and the corners are rounded on recents as they should be. On LOS, dialogs and QS may be rounded, too but couldn't get to test it.
/ According to my tests on RevengeOS and dotOS for Seed, enabling rounded corners on windows also helps improving performance. I'll be making video recordings for both stages, upload to my Drive and send links to those video files as a comment.